### PR TITLE
Implement genre filtering on the Dicover page

### DIFF
--- a/components/movies/Discover.tsx
+++ b/components/movies/Discover.tsx
@@ -1,31 +1,44 @@
-import { useRouter } from 'next/router';
-import { useState } from 'react';
+import type { MouseEvent } from 'react';
+
 import useSWR from 'swr';
+import { useRouter } from 'next/router';
+import { useQueryParams } from '@/hooks/useSearchParams';
 
 import ExtendedMovieList from '../common/movies/ExtendedMovieList';
 import Spinner from '../common/spinner/Spinner';
 import Filters from './Filters';
 
-import { getSelectedSortOption } from './utils';
+import {
+  addGenreToQuery,
+  removeGenreFromQuery,
+  markSelectedGenreOptions,
+  getSelectedSortOption,
+} from './utils';
 
 type Props = {
   movieList: movie.MovieList;
-  movieGenres: movie.GenreList;
+  movieGenres: filters.GenreList;
 };
 
 const Discover = ({ movieList, movieGenres }: Props) => {
-  const router = useRouter();
-  const page = router.query.page;
-  const selectedSortOption = getSelectedSortOption(
-    router.query.sort_by as string
-  );
+  const { query } = useRouter();
 
-  const [query, setQuery] = useState<string>(
-    `include_adult=false&include_video=false&language=en-US&page=${page}&sort_by=${selectedSortOption.value}`
-  );
+  const {
+    page: queryPage,
+    sort_by: querySortOption,
+    with_genres: queryGenres,
+  } = query as Record<string, string>;
+
+  const selectedSortOption = getSelectedSortOption(querySortOption);
+  const genres = markSelectedGenreOptions(movieGenres, queryGenres);
+
+  const { queryParams, updateQueryParams } = useQueryParams({
+    page: queryPage,
+    sort_by: querySortOption,
+  });
 
   const { data, isLoading } = useSWR<movie.MovieList>(
-    `${process.env.NEXT_PUBLIC_INTERNAL_API_URL}/movies/discover?${query}`,
+    `${process.env.NEXT_PUBLIC_INTERNAL_API_URL}/movies/discover?${queryParams}`,
     {
       fallbackData: movieList,
     }
@@ -33,13 +46,32 @@ const Discover = ({ movieList, movieGenres }: Props) => {
 
   const handleSortOptionChange = (option: filters.SortOption | null) => {
     if (option) {
-      setQuery(`sort_by=${option.value}&page=${page}`);
-      router.replace(
-        `/movies/discover?sort_by=${option.value}&page=${page}`,
-        undefined,
-        { shallow: true }
-      );
+      const queryParams = {
+        sort_by: option.value,
+        ...(queryGenres && { with_genres: queryGenres }),
+        page: queryPage,
+      };
+
+      updateQueryParams(queryParams);
     }
+  };
+
+  const handleGenreSelect = (
+    e: MouseEvent<HTMLButtonElement>,
+    removeGenre: boolean
+  ) => {
+    const selectedGenre = e.currentTarget.getAttribute('name') as string;
+    const updatedQueryGenres = removeGenre
+      ? addGenreToQuery(queryGenres, selectedGenre)
+      : removeGenreFromQuery(queryGenres, selectedGenre);
+
+    const queryParams = {
+      sort_by: querySortOption,
+      ...(updatedQueryGenres && { with_genres: updatedQueryGenres }),
+      page: queryPage,
+    };
+
+    updateQueryParams(queryParams);
   };
 
   if (data) {
@@ -48,9 +80,10 @@ const Discover = ({ movieList, movieGenres }: Props) => {
         <h1 className='mb-12'>Discover</h1>
         <div className='grid grid-cols-1/4 gap-7'>
           <Filters
-            movieGenres={movieGenres}
+            movieGenres={genres}
             sortOption={selectedSortOption}
             handleSortOptionChange={handleSortOptionChange}
+            handleGenreSelect={handleGenreSelect}
           />
           {isLoading ? (
             <div className='flex justify-center items-center'>

--- a/components/movies/Filters.tsx
+++ b/components/movies/Filters.tsx
@@ -1,3 +1,5 @@
+import type { MouseEvent } from 'react';
+
 import { useId } from 'react';
 import Select from 'react-select';
 
@@ -6,15 +8,20 @@ import FilterItem from './FilterItem';
 import { sortOptions } from './constants';
 
 type Props = {
-  movieGenres: movie.GenreList;
+  movieGenres: filters.GenreList;
   sortOption: filters.SortOption;
   handleSortOptionChange: (option: filters.SortOption | null) => void;
+  handleGenreSelect: (
+    e: MouseEvent<HTMLButtonElement>,
+    remove: boolean
+  ) => void;
 };
 
 const Filters = ({
   movieGenres,
   sortOption,
   handleSortOptionChange,
+  handleGenreSelect,
 }: Props) => {
   const id = useId();
 
@@ -32,9 +39,14 @@ const Filters = ({
       </FilterItem>
       <FilterItem title='Genre'>
         <ul className='flex flex-wrap gap-3'>
-          {movieGenres.genres.map(genre => (
+          {movieGenres.map(genre => (
             <li key={genre.id}>
-              <button className='py-1 px-2 border border-gray-300 rounded-lg'>
+              <button
+                className={`py-1 px-2 border border-gray-300 rounded-lg${
+                  genre.selected ? ' bg-blue-600 text-gray-50' : ''
+                }`}
+                name={genre.id.toString()}
+                onClick={e => handleGenreSelect(e, !genre.selected)}>
                 {genre.name}
               </button>
             </li>

--- a/components/movies/constants.ts
+++ b/components/movies/constants.ts
@@ -1,10 +1,10 @@
 export const sortOptions: readonly { value: string; label: string }[] = [
-  { value: 'popularity.asc', label: 'Popularity ascending' },
-  { value: 'popularity.desc', label: 'Popularity descending' },
-  { value: 'revenue.asc', label: 'Revenue ascending' },
-  { value: 'revenue.desc', label: 'Revenue descending' },
-  { value: 'primary_release_date.asc', label: 'Release date ascending' },
-  { value: 'primary_release_date.desc', label: 'Release date descending' },
-  { value: 'vote_average.asc', label: 'Vote ascending' },
-  { value: 'vote_average.desc', label: 'Vote descending' },
+  { value: 'popularity.asc', label: 'Popularity Ascending' },
+  { value: 'popularity.desc', label: 'Popularity Descending' },
+  { value: 'revenue.asc', label: 'Revenue Ascending' },
+  { value: 'revenue.desc', label: 'Revenue Descending' },
+  { value: 'primary_release_date.asc', label: 'Release Date Ascending' },
+  { value: 'primary_release_date.desc', label: 'Release Date Descending' },
+  { value: 'vote_average.asc', label: 'Vote Ascending' },
+  { value: 'vote_average.desc', label: 'Vote Descending' },
 ];

--- a/components/movies/utils.ts
+++ b/components/movies/utils.ts
@@ -5,3 +5,43 @@ export const getSelectedSortOption = (value: string): filters.SortOption => {
     option => option.value === value
   ) as filters.SortOption;
 };
+
+export const markSelectedGenreOptions = (
+  genreList: filters.GenreList,
+  selectedGenres: string | undefined
+) => {
+  if (selectedGenres) {
+    const selectedGenresArr = selectedGenres.split(',');
+    return genreList.map(genre => {
+      return selectedGenresArr.indexOf(`${genre.id}`) !== -1
+        ? { ...genre, selected: true }
+        : genre;
+    });
+  }
+  return genreList;
+};
+
+export const addGenreToQuery = (selectedGenreIds = '', id: string) => {
+  const valuePresent = selectedGenreIds.match(id);
+
+  if (selectedGenreIds && !valuePresent) {
+    return `${selectedGenreIds},${id}`;
+  }
+
+  if (valuePresent) {
+    return selectedGenreIds;
+  }
+
+  return id;
+};
+
+export const removeGenreFromQuery = (selectedGenreIds: string, id: string) => {
+  const genresArr = selectedGenreIds.split(',');
+
+  if (genresArr.length === 1) {
+    return '';
+  }
+
+  const updatedArr = genresArr.filter(currId => currId !== id);
+  return updatedArr.join(',');
+};

--- a/hooks/useSearchParams.tsx
+++ b/hooks/useSearchParams.tsx
@@ -1,0 +1,20 @@
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+
+export const useQueryParams = (initialQueryParams: Record<string, string>) => {
+  const router = useRouter();
+  const [queryParams, setQueryParams] = useState(
+    new URLSearchParams(initialQueryParams).toString()
+  );
+
+  const updateQueryParams = (queryParamsObj: Record<string, string>) => {
+    const queryParams = new URLSearchParams(queryParamsObj);
+
+    setQueryParams(queryParams.toString());
+    router.replace({ query: queryParams.toString() }, undefined, {
+      shallow: true,
+    });
+  };
+
+  return { queryParams, updateQueryParams };
+};

--- a/pages/api/movies/discover.ts
+++ b/pages/api/movies/discover.ts
@@ -16,15 +16,19 @@ export default async function handler(
 
   if (req.method === 'GET') {
     let fetchRes: Response;
-    const { sort_by, page } = req.query;
+    const { sort_by, with_genres, page } = req.query as Record<string, string>;
+
+    const queryParams = new URLSearchParams({
+      include_adult: 'false',
+      language: 'en-US',
+      sort_by,
+      ...(with_genres && { with_genres }),
+      page: page || '1',
+    });
 
     try {
       fetchRes = await fetch(
-        `${
-          process.env.API_URL
-        }/discover/movie?include_adult=false&include_video=false&language=en-US&page=${
-          page || 1
-        }&sort_by=${sort_by}`,
+        `${process.env.API_URL}/discover/movie?${queryParams.toString()}`,
         options
       );
 

--- a/pages/movies/discover.tsx
+++ b/pages/movies/discover.tsx
@@ -6,6 +6,8 @@ import Discover from '@/components/movies/Discover';
 export const getServerSideProps = (async context => {
   const { query } = context;
 
+  const { page, sort_by, with_genres } = query as Record<string, string>;
+
   const options = {
     method: 'GET',
     headers: {
@@ -14,12 +16,16 @@ export const getServerSideProps = (async context => {
     },
   };
 
+  const queryParams = new URLSearchParams({
+    include_adult: 'false',
+    language: 'en-US',
+    page: page || '1',
+    sort_by,
+    ...(with_genres && { with_genres }),
+  });
+
   const moviewRes = await fetch(
-    `${
-      process.env.API_URL
-    }/discover/movie?include_adult=false&include_video=false&language=en-US&page=${
-      query.page || 1
-    }&sort_by=${query.sort_by}`,
+    `${process.env.API_URL}/discover/movie?${queryParams.toString()}`,
     options
   );
 
@@ -32,13 +38,13 @@ export const getServerSideProps = (async context => {
   const movieGenres = await movieGenresRes.json();
 
   return {
-    props: { movieList, movieGenres },
+    props: { movieList, movieGenres: movieGenres.genres },
   };
 }) satisfies GetServerSideProps;
 
 type Props = {
   movieList: movie.MovieList;
-  movieGenres: movie.GenreList;
+  movieGenres: movie.Genre[];
 };
 
 const DiscoverPage = ({ movieList, movieGenres }: Props) => {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4,10 +4,6 @@ namespace movie {
     name: string;
   };
 
-  type GenreList = {
-    genres: Genre[];
-  };
-
   type Movie = {
     adult: boolean;
     genres: Genre[];
@@ -46,7 +42,7 @@ namespace navbar {
       | string
       | {
           pathname: string;
-          query: { [key: string]: string };
+          query: Record<string, string>;
         };
   };
 
@@ -58,5 +54,9 @@ namespace navbar {
 }
 
 namespace filters {
-  type SortOption = { value: string | number; label: string };
+  type SortOption = { value: string; label: string };
+
+  type GenreList = (movie.Genre & {
+    selected?: boolean;
+  })[];
 }


### PR DESCRIPTION
Changes:
1) Added the ability to filter by genres on the Discover page
2) Added new hook `useQueryParams` in order to avoid code duplication
3) Moved query parameters to the `URLSearchParams` object