### PR TITLE
Change image resolution fetched from the API

### DIFF
--- a/components/common/home/MovieCarouselItem.tsx
+++ b/components/common/home/MovieCarouselItem.tsx
@@ -18,12 +18,13 @@ const MovieCarouselItem = ({ movie }: Props) => {
       <article className='relative flex flex-col rounded-xl overflow-hidden'>
         <MovieImage
           imageSrc={movie.poster_path}
-          serverWidth={400}
+          serverWidth={200}
           width={200}
           height={400}
           className='hover:opacity-90 transition-all'
-          sizes='30vw'
+          sizes='90vw'
           alt='Movie poster'
+          priority
         />
         <div className='p-2'>
           <div

--- a/components/common/movies/Movie.tsx
+++ b/components/common/movies/Movie.tsx
@@ -18,10 +18,10 @@ const Movie = ({ movie }: Props) => {
       <div className='relative w-full max-w-xl aspect-5/7 mb-5 rounded-xl overflow-hidden'>
         <MovieImage
           imageSrc={movie.poster_path}
-          serverWidth={400}
+          serverWidth={300}
           fill
           alt='Movie poster'
-          sizes='(max-width: 768px) 15vw, (max-width: 1200px) 25vw, 30vw'
+          sizes='(max-width: 768px) 70vw, (max-width: 1200px) 90vw, 100vw'
           style={{ objectFit: 'cover' }}
         />
       </div>

--- a/components/home/trending/MovieDetails.tsx
+++ b/components/home/trending/MovieDetails.tsx
@@ -8,15 +8,15 @@ type Props = {
 
 const MovieDetails = ({ movie }: Props) => {
   return (
-    <div className='flex flex-col text-slate-200'>
+    <div className='text-slate-200 pb-12 basis-1/2'>
       <h3>{movie.title}</h3>
-      <p className='mt-5'>{movie.overview}</p>
+      <p className='my-5'>{movie.overview}</p>
       <Link
         href={{
           pathname: '/movies/details/[id]',
           query: { id: movie.id },
         }}
-        className="mt-5 text-xl w-fit after:content-[''] after:block after:w-0 after:bg-slate-100 after:h-[2px] after:hover:w-full after:transition-all after:duration-500">
+        className='block mt-5 text-xl w-fit after:block after:w-0 after:bg-slate-100 after:h-[2px] after:hover:w-full after:transition-all after:duration-500'>
         View
       </Link>
     </div>

--- a/components/home/trending/TrendingMovie.tsx
+++ b/components/home/trending/TrendingMovie.tsx
@@ -9,11 +9,11 @@ type Props = {
 
 const TrendingMovie = ({ movie }: Props) => {
   return (
-    <article className='min-h-screen flex flex-col xl:flex-row gap-y-5 xl:gap-x-20 px-12 pt-28 pb-10 xl:px-28 xl:py-48'>
-      <div className='absolute bottom-0 left-0 right-0 top-0 h-full w-full overflow-hidden bg-gradient-to-b from-slate-950 via-slate-700 to-slate-300 opacity-70 -z-10'></div>
+    <article className='min-h-screen flex flex-col lg:flex-row items-center gap-12 lg:gap-x-12 xl:gap-x-20 pt-12 lg:pt-0 px-12 md:px-16 lg:px-20 xl:px-28'>
+      <div className='absolute top-0 left-0 h-full w-full overflow-hidden bg-gradient-to-b from-slate-950 via-slate-700 to-slate-300 opacity-70 -z-10'></div>
       <MovieImage
         imageSrc={movie.poster_path}
-        serverWidth={'original'}
+        serverWidth={400}
         fill
         style={{
           objectFit: 'cover',
@@ -24,16 +24,16 @@ const TrendingMovie = ({ movie }: Props) => {
         alt='Movie background poster'
         priority
       />
-      <MovieImage
-        imageSrc={movie.poster_path}
-        serverWidth={500}
-        width={350}
-        height={400}
-        sizes='50vw'
-        alt='Movie poster'
-        priority
-        className='self-center'
-      />
+      <div className='relative aspect-2/3 lg:basis-1/4 lg:max-w-2xl w-full sm:w-8/12'>
+        <MovieImage
+          imageSrc={movie.poster_path}
+          serverWidth={500}
+          fill
+          sizes='100vw'
+          alt='Movie poster'
+          priority
+        />
+      </div>
       <MovieDetails movie={movie} />
     </article>
   );

--- a/components/home/trending/TrendingMovies.tsx
+++ b/components/home/trending/TrendingMovies.tsx
@@ -16,21 +16,19 @@ type Props = {
 
 const TrendingMovies = ({ moviesRes }: Props) => {
   return (
-    <section className='relative'>
-      <Swiper
-        style={{
-          '--swiper-navigation-color': '#fff',
-        }}
-        navigation
-        loop
-        modules={[Navigation]}>
-        {moviesRes.results.map(movie => (
-          <SwiperSlide key={movie.id} style={{ height: 'auto' }}>
-            <TrendingMovie movie={movie} />
-          </SwiperSlide>
-        ))}
-      </Swiper>
-    </section>
+    <Swiper
+      style={{
+        '--swiper-navigation-color': '#fff',
+      }}
+      navigation
+      loop
+      modules={[Navigation]}>
+      {moviesRes.results.map(movie => (
+        <SwiperSlide key={movie.id} style={{ height: 'auto' }}>
+          <TrendingMovie movie={movie} />
+        </SwiperSlide>
+      ))}
+    </Swiper>
   );
 };
 

--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -16,7 +16,7 @@ const Layout = ({ children, px = true, py = true }: LayoutProps) => {
       <Navbar />
       <main
         className={`relative ${px ? 'px-7 md:px-10 xl:px-40' : ''} ${
-          py ? 'pt-24 md:pt-32 xl:pt-40 pb-12' : ''
+          py ? 'pt-8 md:pt-12 xl:pt-20 pb-12' : ''
         } ${roboto.className}`}>
         {children}
       </main>

--- a/components/layout/navbar/Navbar.tsx
+++ b/components/layout/navbar/Navbar.tsx
@@ -10,7 +10,7 @@ const roboto = Roboto({ subsets: ['latin'], weight: ['400'] });
 const Navbar = () => {
   return (
     <nav
-      className={`fixed w-full z-50 flex items-center justify-between h-16 px-12 xl:px-16 bg-gray-800 text-slate-100 ${roboto.className}`}>
+      className={`sticky top-0 left-0 w-full z-50 flex items-center justify-between h-16 px-12 xl:px-16 bg-gray-800 text-slate-100 ${roboto.className}`}>
       <Link href={'/'}>
         <h2>Movies</h2>
       </Link>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,6 +14,7 @@ const config: Config = {
       aspectRatio: {
         '5/7': '5 / 7',
         '3/1': '3 / 1',
+        '2/3': '2 / 3',
       },
       gridTemplateColumns: {
         '1/4': '1fr 4fr',


### PR DESCRIPTION
These changes should increase the speed of image retrieving and showing them to user.

Changes:

- Changed navbar positioning to `sticky`
- Changed remote image resolution for trending movies
- After the image resoultion was changed inside `TrendingMovies` it was not cosistent with positioning so it was required to change the styling in order to achieve the previous behavior
- Changed remote image resolution for movie carousel
- Changed remote image resoultion for movie list