### PR TITLE
Handle genres fetch result inside DesktopFilters

### DIFF
--- a/app/components/tv/discover/filters/DesktopFilters.tsx
+++ b/app/components/tv/discover/filters/DesktopFilters.tsx
@@ -1,18 +1,25 @@
-import type { filters } from '@/typings/filters';
+import type { api } from '@/typings/api';
 
-import GenresFilter from './GenresFilter';
+import GenresFilter from './genres/GenresFilter';
 import SortFilter from './SortFilter';
+import GenresError from '@/app/components/ui/errors/filters/GenresError';
 
 type Props = {
-  genres: filters.GenreList;
+  genresRes: api.FetcherResponse<api.GenreResponse>;
 };
 
-export default function DesktopFilters({ genres }: Props) {
+export default function DesktopFilters({ genresRes }: Props) {
+  if (genresRes.error) {
+    return (
+      <GenresError wrapperClasses='hidden md:flex flex-col items-center justify-center bg-gray-300 rounded-xl h-[600px] p-11' />
+    );
+  }
+
   return (
     <section className='hidden md:block p-5 border border-gray-200 shadow-xl rounded-2xl h-fit mb-8'>
       <h3>Filters</h3>
       <SortFilter />
-      <GenresFilter genres={genres} />
+      <GenresFilter genres={genresRes.data.genres} />
     </section>
   );
 }

--- a/app/components/ui/errors/filters/GenresError.tsx
+++ b/app/components/ui/errors/filters/GenresError.tsx
@@ -1,0 +1,18 @@
+import type { HTMLAttributes } from 'react';
+
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+
+type Props = {
+  wrapperClasses: HTMLAttributes<HTMLDivElement>['className'];
+};
+
+export default function GenresError({ wrapperClasses }: Props) {
+  return (
+    <div className={wrapperClasses}>
+      <ErrorOutlineIcon fontSize='large' className='mb-5'/>
+      <p>Failed to load genres.</p>
+      <p> Please reload the page.</p>
+      <p className='text-xs mt-4'>If the error persists, contact us.</p>
+    </div>
+  );
+}

--- a/app/components/ui/filters/DesktopFiltersError.tsx
+++ b/app/components/ui/filters/DesktopFiltersError.tsx
@@ -1,9 +1,0 @@
-export default function FiltersError() {
-  return (
-    <div className='hidden md:flex flex-col items-center justify-center bg-gray-300 rounded-xl h-[600px] p-11'>
-      <p>Failed to load genres.</p>
-      <p> Please reload the page.</p>
-      <p className='text-xs mt-4'>If the error persists, contact us.</p>
-    </div>
-  );
-}

--- a/app/tv/discover/_filters/filters.tsx
+++ b/app/tv/discover/_filters/filters.tsx
@@ -1,13 +1,17 @@
 'use client';
 
-import type { filters } from '@/typings/filters';
+import type { api } from '@/typings/api';
 
 import DesktopFilters from '@/app/components/tv/discover/filters/DesktopFilters';
 
 type Props = {
-  genres: filters.GenreList;
+  genresRes: api.FetcherResponse<api.GenreResponse>;
 };
 
-export default function Filters({ genres }: Props) {
-  return <DesktopFilters genres={genres} />;
+export default function Filters({ genresRes }: Props) {
+  return (
+    <>
+      <DesktopFilters genresRes={genresRes} />
+    </>
+  );
 }

--- a/app/tv/discover/_filters/page.tsx
+++ b/app/tv/discover/_filters/page.tsx
@@ -1,16 +1,11 @@
 import type { api } from '@/typings/api';
 
 import Filters from './filters';
-import FiltersError from '@/app/components/ui/filters/DesktopFiltersError';
 
 import { getData } from '@/services/api';
 
 export default async function FiltersPage() {
   const tvGenresRes = await getData<api.GenreResponse>('/genre/tv/list');
 
-  if (tvGenresRes.error) {
-    return <FiltersError />;
-  }
-
-  return <Filters genres={tvGenresRes.data.genres} />;
+  return <Filters genresRes={tvGenresRes} />;
 }

--- a/services/api.ts
+++ b/services/api.ts
@@ -2,8 +2,6 @@ import type { api } from '@/typings/api';
 
 import { getEnvironmentVariable } from '@/utils/utils';
 
-type FetcherResponse<T> = api.SuccessResponse<T> | api.ErrorResponse;
-
 export const fetcher = async <T>(url: string, ...args: [any]): Promise<T> => {
   const res = await fetch(url, ...args);
   const json = await res.json();
@@ -51,6 +49,8 @@ export const getData = async <T>(
 ): Promise<FetcherResponse<T>> => {
   const bearer = getEnvironmentVariable('API_BEARER');
   const apiURL = getEnvironmentVariable('API_URL');
+
+  // await new Promise(resolve => setTimeout(resolve, 3000));
 
   const _options = {
     ...options,

--- a/typings/api.ts
+++ b/typings/api.ts
@@ -1,3 +1,4 @@
+import type { Genre } from './common';
 import type { movie } from './movie/movie';
 
 export namespace api {
@@ -35,7 +36,9 @@ export namespace api {
     data: Awaited<T>;
   };
 
+  export type FetcherResponse<T> = SuccessResponse<T> | ErrorResponse;
+
   export type GenreResponse = {
-    genres: movie.Genre[];
+    genres: Genre[];
   };
 }


### PR DESCRIPTION
Changes:

- Added the ability to handle genres fetch result inside `DesktopFilters`
- Moved `FetcherResponse` type to `api` namespace to be able to export it where it needed
- Updated genres error content